### PR TITLE
Exit Function

### DIFF
--- a/src/js/base/repl-lib.js
+++ b/src/js/base/repl-lib.js
@@ -17,7 +17,7 @@ define(["q", "js/eval-lib", "compiler/repl-support.arr"], function(Q, eval, rs) 
       function get(obj, fld) { return runtime.getField(obj, fld); }
       
       // adding `exit` function into the environment
-      var exitFunction = runtime.makeFunction(function(exitcode) {
+      var exitFunction = runtime.makeFunction(function() {
         runtime.checkArity(0, arguments, 'exit');
         process.exit();
       })

--- a/src/js/base/repl-lib.js
+++ b/src/js/base/repl-lib.js
@@ -15,6 +15,19 @@ define(["q", "js/eval-lib", "compiler/repl-support.arr"], function(Q, eval, rs) 
       var toRun = [];
       var somethingRunning = false;
       function get(obj, fld) { return runtime.getField(obj, fld); }
+      
+      // adding `exit` function into the environment
+      var exitFunction = runtime.makeFunction(function(exitcode) {
+        if (typeof exitcode === "undefined") {
+          process.exit();
+        }
+        process.exit(exitcode);
+      })
+      namespace = namespace.set('exit', exitFunction)
+      namespace = namespace.set('quit', exitFunction)
+      initialCompileEnv = get(replSupport, "add-global-binding").app(initialCompileEnv, "exit");
+      initialCompileEnv = get(replSupport, "add-global-binding").app(initialCompileEnv, "quit");
+      
       var mainCompileEnv = initialCompileEnv;
       var initialReplCompileEnv = get(replSupport, "drop-module-bindings").app(mainCompileEnv);
       var replCompileEnv = initialReplCompileEnv;

--- a/src/js/base/repl-lib.js
+++ b/src/js/base/repl-lib.js
@@ -18,15 +18,20 @@ define(["q", "js/eval-lib", "compiler/repl-support.arr"], function(Q, eval, rs) 
       
       // adding `exit` function into the environment
       var exitFunction = runtime.makeFunction(function(exitcode) {
-        if (typeof exitcode === "undefined") {
-          process.exit();
-        }
+        runtime.checkArity(0, arguments, 'exit');
+        process.exit();
+      })
+      var exitCodeFunction = runtime.makeFunction(function(exitcode) {
+        runtime.checkArity(1, arguments, 'exit-code');
+        runtime.checkNumber(exitcode);
         process.exit(exitcode);
       })
       namespace = namespace.set('exit', exitFunction)
       namespace = namespace.set('quit', exitFunction)
+      namespace = namespace.set('exit-code', exitCodeFunction)
       initialCompileEnv = get(replSupport, "add-global-binding").app(initialCompileEnv, "exit");
       initialCompileEnv = get(replSupport, "add-global-binding").app(initialCompileEnv, "quit");
+      initialCompileEnv = get(replSupport, "add-global-binding").app(initialCompileEnv, "exit-code");
       
       var mainCompileEnv = initialCompileEnv;
       var initialReplCompileEnv = get(replSupport, "drop-module-bindings").app(mainCompileEnv);


### PR DESCRIPTION
I have added an exit/quit function, which supports exit code.
Could anyone peer-review my code? I am open for comments.

Meanwhile, if the user types `exit`, the REPL will give '<function>'. I am thinking about giving a more informative message if the user does not call it correct as `exit()`. In Python, the `exit` command is realized by an object, which has an `__repr__` for the message and an `__init__` for the real exit behavior. 

It seems like a 'data' in Pyret, whose `_torepr(self :: Quitter, shadow torepr :: (Any -> String)) -> String` can be the equivalence of `__repr__`, but I cannot find an equivalence of `__init__`. Any suggestions?

I also don't understand what does `shadow torepr :: (Any -> String)` do in the `_torepr` definition.
